### PR TITLE
Update README: fix link to ZioShieldShowCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Running `shield` command will start the analysis.
 ...
 ```
 
-`ZioShieldShowcase.scala` source code located [here](shield-api/src/test/scala/zio/shield/rules/examples/ZioShieldShowcase.scala).
+`ZioShieldShowcase.scala` source code located [here](shield-tests/src/test/scala/zio/shield/rules/examples/ZioShieldShowcase.scala).
+
 
 #### Configuration
 


### PR DESCRIPTION
The link to the examples showcase returns a 404 error. It looks like the location of the showcase file moved under the `shield-tests` module.